### PR TITLE
Temporary fix for zoro sources - empty array

### DIFF
--- a/src/providers/anime/zoro/service/zoro.fetch.service.ts
+++ b/src/providers/anime/zoro/service/zoro.fetch.service.ts
@@ -63,11 +63,12 @@ export class ZoroFetchService extends Client {
       intro: streamingLink.intro,
       outro: streamingLink.outro,
       sources: [
-        {
+        // TEMPORARY FIX!! Servers for M3U8 are blocking access
+        /*{
           url: streamingLink.link.file,
           isM3U8: streamingLink.link.type === 'hls',
           type: streamingLink.link.type,
-        },
+        },*/
       ],
     });
   }


### PR DESCRIPTION
Commented out the sources, so it'll supply an empty array.
Reason: We are getting blocked.
<img width="1042" height="887" alt="image" src="https://github.com/user-attachments/assets/1310852f-1f60-4e42-8bf0-17093560e05f" />
