### PR TITLE
Added custom header support for proxy and removed proxy url from sources

### DIFF
--- a/src/providers/anime/animekai/service/animekai.fetch.service.ts
+++ b/src/providers/anime/animekai/service/animekai.fetch.service.ts
@@ -26,11 +26,6 @@ export class AnimekaiFetchService extends Client {
       throw new Error('Data is null');
     }
 
-    data.sources = data.sources.map((s) => ({
-      ...s,
-      url: s.isM3U8 ? `${UrlConfig.PROXY_URL}${s.url}` : s.url,
-    }));
-
     return data;
   }
 

--- a/src/providers/anime/animepahe/service/animepahe.fetch.service.ts
+++ b/src/providers/anime/animepahe/service/animepahe.fetch.service.ts
@@ -26,11 +26,6 @@ export class AnimepaheFetchService extends Client {
       throw new Error('Data is null');
     }
 
-    data.sources = data.sources.map((s) => ({
-      ...s,
-      url: s.isM3U8 ? `${UrlConfig.PROXY_URL}${s.url}` : s.url,
-    }));
-
     return data;
   }
 

--- a/src/providers/anime/zoro/service/zoro.fetch.service.ts
+++ b/src/providers/anime/zoro/service/zoro.fetch.service.ts
@@ -64,7 +64,7 @@ export class ZoroFetchService extends Client {
       outro: streamingLink.outro,
       sources: [
         {
-          url: `${UrlConfig.PROXY_URL}${streamingLink.link.file}`,
+          url: streamingLink.link.file,
           isM3U8: streamingLink.link.type === 'hls',
           type: streamingLink.link.type,
         },

--- a/src/providers/proxy/service/proxy.service.ts
+++ b/src/providers/proxy/service/proxy.service.ts
@@ -11,13 +11,20 @@ const httpAgent = new http.Agent({ keepAlive: true });
 const httpsAgent = new https.Agent({ keepAlive: true });
 
 export class ProxyService {
-  async fetchProxiedStream(url: string): Promise<{
+  async fetchProxiedStream(
+    url: string,
+    customHeaders: Record<string, string> = {},
+  ): Promise<{
     content: Buffer | Readable;
     headers: Record<string, string | undefined>;
     isStream: boolean;
   }> {
+    // Merging the headers, custom headers take priority
+    const providerHeaders = this.getHeaders(url);
+    const mergedHeaders = { ...providerHeaders, ...customHeaders };
+
     const response = await axios.get<Readable>(url, {
-      headers: this.getHeaders(url),
+      headers: mergedHeaders,
       responseType: 'stream',
       decompress: false,
       timeout: 10000,
@@ -26,6 +33,7 @@ export class ProxyService {
       httpsAgent,
     });
 
+    // Response headers
     const headers = response.headers as Record<string, string | undefined>;
     const contentType = headers['content-type'] || '';
 


### PR DESCRIPTION
The first part, adding custom header support, isn't considered a breaking change.
The second part, removing the proxy url form the sources, may be considered a breaking change leading users to being forced to manually craft the proxy url with the source.
Why adding custom header support? The user should be able to use custom headers in case the automated source detector fails.
Why removing the proxy url from the source? Users tend to use their own proxies instead this in built one, manually removing the proxy url from the source might be considered annoying or unnecessary work.